### PR TITLE
Added metadata extras standard implementation proposal

### DIFF
--- a/aiida_jutools/__init__.py
+++ b/aiida_jutools/__init__.py
@@ -34,7 +34,13 @@ from . import structure
 from . import _dev
 
 # Potentially problematic imports:
-# - kkr: As soon as aiida-kkr becomes dependent on aiida-jutools, this import could introduce a circular
-#        dependency. One solution to that might be to *not* import kkr here, but require that it is imported
-#        separately by the user, e.g. like from aiida_jutools import kkr as _jutools_kkr.
-
+# - kkr: As soon as aiida-kkr becomes dependent on aiida-jutools, this import MIGHT introduce a circular
+#        dependencies. A simple test (made aiida-kkr import aiida-jutools) had no such effect. But if it
+#        occurs, here a few potential solutions:
+#        - Decouple the kkr package = remove from import list above. Then all code using it must be updated
+#          to import it separately, like from aiida_jutools import kkr as _jutools_kkr. Might break external code.
+#        - Hide all aiida-kkr imports = in resp. module, move them inside the tools that use them. If it works,
+#          this might be a solution that does not break external code.
+#
+# The potential problem and the solution stated above, if it becomes one, applies to other JuDFTTeam plugins as well,
+# should they start using aiida-jutools as common codebase (aiida-fleur, aiida-spirit, aiida-spex, ...).

--- a/aiida_jutools/__init__.py
+++ b/aiida_jutools/__init__.py
@@ -12,23 +12,29 @@
 ###############################################################################
 """AiiDA JuTools.
 
-We recommended to use this package with the import statement ``import aiida_jutools as jutools``. In your code,
-you can then call all available tools like so: ``jutools.subpackage.tool()``.
+We recommended to use this library with the import statement ``import aiida_jutools as jutools``. In your code,
+you can then call all available tools like so: ``jutools.package.tool()``.
 """
 __version__ = "0.1.0-dev1"
 
-# Import all user subpackages.
+# Import all of the library's user packages.
 from . import code
 from . import computer
 from . import group
 from . import io
 from . import kkr
 from . import logging
+from . import meta
 from . import node
 from . import process
 from . import process_functions
 from . import submit
 from . import structure
-# # import developer subpackages.
+# # import all of the library's developer packages.
 from . import _dev
+
+# Potentially problematic imports:
+# - kkr: As soon as aiida-kkr becomes dependent on aiida-jutools, this import could introduce a circular
+#        dependency. One solution to that might be to *not* import kkr here, but require that it is imported
+#        separately by the user, e.g. like from aiida_jutools import kkr as _jutools_kkr.
 

--- a/aiida_jutools/_dev/__init__.py
+++ b/aiida_jutools/_dev/__init__.py
@@ -15,6 +15,6 @@
 from .periodic_tables import \
     minimal_periodic_table
 
-# not importing constants from .terminal_colors to subpackage since large number of constants.
-# instead, import locally from module.
+# not importing constants from .terminal_colors to this namespace (currently, jutools._dev) since large number of
+# constants. instead, import locally from module explicitly:
 # from .terminal_colors import *

--- a/aiida_jutools/kkr/__init__.py
+++ b/aiida_jutools/kkr/__init__.py
@@ -10,9 +10,12 @@
 # For further information please visit http://judft.de/.                      #
 #                                                                             #
 ###############################################################################
-"""Tools for working with aiida-kkr nodes."""
+"""Tools for working with aiida-kkr nodes.
+
+Note: Prefer importing """
 
 from .constants import \
+    get_runtime_kkr_constants_version, \
     KkrConstantsVersion, \
     KkrConstantsVersionChecker
 

--- a/aiida_jutools/meta/__init__.py
+++ b/aiida_jutools/meta/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+# Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
+#                All rights reserved.                                         #
+# This file is part of the aiida-jutools package.                             #
+# (AiiDA JuDFT tools)                                                         #
+#                                                                             #
+# The code is hosted on GitHub at https://github.com/judftteam/aiida-jutools. #
+# For further information on the license, see the LICENSE.txt file.           #
+# For further information please visit http://judft.de/.                      #
+#                                                                             #
+###############################################################################
+"""Tools for working with AiiDA metadata / annotations."""
+
+# import subpackages
+from . import extra
+
+# tools visible on this level
+from .extra.util import \
+    ExtraFormFactory

--- a/aiida_jutools/meta/extra/__init__.py
+++ b/aiida_jutools/meta/extra/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+# Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
+#                All rights reserved.                                         #
+# This file is part of the aiida-jutools package.                             #
+# (AiiDA JuDFT tools)                                                         #
+#                                                                             #
+# The code is hosted on GitHub at https://github.com/judftteam/aiida-jutools. #
+# For further information on the license, see the LICENSE.txt file.           #
+# For further information please visit http://judft.de/.                      #
+#                                                                             #
+###############################################################################
+"""Tools for working with AiiDA metadata / annotations: extras."""
+
+# import subpackages
+from . import forms
+
+# import all tools from util
+from .util import \
+    ExtraForm, \
+    ExtraFormFactory
+
+

--- a/aiida_jutools/meta/extra/forms/KkrConstantsVersion.py
+++ b/aiida_jutools/meta/extra/forms/KkrConstantsVersion.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+# Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
+#                All rights reserved.                                         #
+# This file is part of the aiida-jutools package.                             #
+# (AiiDA JuDFT tools)                                                         #
+#                                                                             #
+# The code is hosted on GitHub at https://github.com/judftteam/aiida-jutools. #
+# For further information on the license, see the LICENSE.txt file.           #
+# For further information please visit http://judft.de/.                      #
+#                                                                             #
+###############################################################################
+"""Tools for working with AiiDA metadata / annotations: extras: forms: KkrConstantsVersion."""
+
+import typing as _typing
+
+import masci_tools.util.python_util as _masci_python_util
+import masci_tools.util.constants as _masci_constants
+from aiida import orm as _orm
+
+from aiida_jutools.kkr import KkrConstantsVersion as _KkrConstantsVersion, \
+    get_runtime_kkr_constants_version as _get_runtime_kkr_constants_version
+from ..util import ExtraForm as _ExtraForm
+
+
+class KkrConstantsVersionExtraForm(_ExtraForm):
+    """Extra form for setting the conversion constants versions used by an AiiDA calc / workflow.
+
+    This form serves as an example for the implementation of :py:meth:`~.util.ExtraForm.__init__`. As such, it
+    showcases both suggested options to set the form value (subvalues): via the constructor, or via property
+    getters / setters. Normally, only one of the ways would be implemented, preferably the former. In that case,
+    the constructor arguments would be mandatory.
+    """
+
+    def __init__(self,
+                 constants_version: _KkrConstantsVersion = None,
+                 ANG_BOHR_KKR: float = None,
+                 RY_TO_EV_KKR: float = None):
+        """Extends :py:meth:`~.util.ExtraForm.__init__`.
+
+        :param constants_version: version of the conversion constants.
+        :param ANG_BOHR_KKR: value of the Angstrom to Bohr conversion constant.
+        :param RY_TO_EV_KKR: value of the Rydberg to electron Volt conversion constant.
+        """
+        super().__init__()
+        self._key = 'kkr_constants_version'
+        self._value = {
+            'constants_version': constants_version.name if constants_version else constants_version,
+            'ANG_BOHR_KKR': ANG_BOHR_KKR,
+            'RY_TO_EV_KKR': RY_TO_EV_KKR
+        }
+
+    def load(self,
+             entity: _orm.EntityExtrasMixin,
+             **kwargs):
+        """This methods extends :py:meth:`~.util.ExtraForm.load`.
+
+        Additional `kwargs` commands:
+
+        - `silent : bool = True`. False: print warnings.
+
+        :param entity:
+        :type entity:
+        :param kwargs:
+        :type kwargs:
+        """
+        ent_value = entity.get_extra(self._key, default=None)
+        if ent_value and isinstance(ent_value, dict):
+            form_subkeys = set(self._value.keys())
+            ent_subkeys = set(ent_value.keys())
+            for form_subkey in form_subkeys:
+                self._value[form_subkey] = ent_value.get(form_subkey, None)
+
+            silent = kwargs.get('silent', None)
+            if (
+                    silent is not None
+                    and not silent
+                    and form_subkeys != ent_subkeys
+            ):
+                print(f"Warning: Entity {entity} has standardized extra '{self.key}', "
+                      f"but subvalue keys are non-standard or contain an error report: {ent_subkeys}.")
+
+    def validate(self, **kwargs) -> bool:
+        assert isinstance(self.value, dict), "Value must be a dictionary."
+        assert all(subval is not None for subval in self.value.values()), "All subvalues must be set."
+
+        valid_versions = [kcv.name for kcv in [_KkrConstantsVersion.NEW,
+                                               _KkrConstantsVersion.INTERIM,
+                                               _KkrConstantsVersion.OLD]]
+        assert self.value['constants_version'] in valid_versions, f"Constants version must be one of {valid_versions}."
+        # TODO also validate conversion constants values?
+        return True
+
+    def clear(self):
+        super().clear()
+        for value_key in self._value:
+            self._value[value_key] = None
+
+    def get_from_runtime(self,
+                         silent: bool = False) -> bool:
+        """Determine the form's value from runtime.
+
+        :param silent: False: Print warnings.
+        :return: True if determined successfully, False if not.
+        """
+        constants_version = _get_runtime_kkr_constants_version(silent=silent)
+        lookup = {'ANG_BOHR_KKR': constants_version.lookup(constant_name='ANG_BOHR_KKR',
+                                                           silent=silent),
+                  'RY_TO_EV_KKR': constants_version.lookup(constant_name='RY_TO_EV_KKR',
+                                                           silent=silent)}
+        runtime = {'ANG_BOHR_KKR': _masci_constants.ANG_BOHR_KKR,
+                   'RY_TO_EV_KKR': _masci_constants.RY_TO_EV_KKR}
+        # compare with runtime values
+
+        a2b_match = lookup['ANG_BOHR_KKR'] == runtime['ANG_BOHR_KKR']
+        r2e_match = lookup['RY_TO_EV_KKR'] == runtime['RY_TO_EV_KKR']
+        all_match = a2b_match and r2e_match
+
+        if not all_match:
+            constants_version = _KkrConstantsVersion.UNDEFINED
+            error_report = f"Warning: Determined runtime version {constants_version}, but tabulated constants " \
+                           f"values do not match runtime values. One possible reason is that values in " \
+                           f"masci-tools have been updated, and this form is not up to date."
+            if not silent:
+                print(error_report + " I will mark this as undefined, set the runtime values, "
+                                     "and include an error report.")
+            self.insert_error_report(error_report=error_report, overwrite=True)
+
+        self.constants_version = constants_version
+        self.ANG_BOHR_KKR = runtime['ANG_BOHR_KKR']
+        self.RY_TO_EV_KKR = runtime['RY_TO_EV_KKR']
+
+        return all_match
+
+    @property
+    def constants_version(self) -> _typing.Optional[_KkrConstantsVersion]:
+        """Get/set the version of the conversion constants. Internally stored as string."""
+        constants_version = self._value.get('constants_version')
+        try:
+            return _KkrConstantsVersion[constants_version]
+        except KeyError as err:
+            return None
+
+    @constants_version.setter
+    def constants_version(self, constants_version: _KkrConstantsVersion):
+        """Set the version of the conversion constants."""
+        self._value['constants_version'] = constants_version.name
+
+    @property
+    def ANG_BOHR_KKR(self) -> _typing.Optional[float]:
+        """Get/set the value of the Angstrom to Bohr conversion constant."""
+        return self._value.get('ANG_BOHR_KKR', None)
+
+    @ANG_BOHR_KKR.setter
+    def ANG_BOHR_KKR(self, ANG_BOHR_KKR: float):
+        """Get/set the value of the Angstrom to Bohr conversion constant."""
+        self._value['ANG_BOHR_KKR'] = ANG_BOHR_KKR
+
+    @property
+    def RY_TO_EV_KKR(self) -> _typing.Optional[float]:
+        """Get/set the value of the Rydberg to electron Volt conversion constant."""
+        return self._value.get('RY_TO_EV_KKR', None)
+
+    @RY_TO_EV_KKR.setter
+    def RY_TO_EV_KKR(self, RY_TO_EV_KKR: float):
+        """Set the value of the Rydberg to electron Volt conversion constant."""
+        self._value['RY_TO_EV_KKR'] = RY_TO_EV_KKR

--- a/aiida_jutools/meta/extra/forms/__init__.py
+++ b/aiida_jutools/meta/extra/forms/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+# Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
+#                All rights reserved.                                         #
+# This file is part of the aiida-jutools package.                             #
+# (AiiDA JuDFT tools)                                                         #
+#                                                                             #
+# The code is hosted on GitHub at https://github.com/judftteam/aiida-jutools. #
+# For further information on the license, see the LICENSE.txt file.           #
+# For further information please visit http://judft.de/.                      #
+#                                                                             #
+###############################################################################
+"""Tools for working with AiiDA metadata / annotations: extras: forms."""
+
+# import forms from their modules
+from .KkrConstantsVersion import \
+    KkrConstantsVersionExtraForm

--- a/aiida_jutools/meta/extra/util.py
+++ b/aiida_jutools/meta/extra/util.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+# Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
+#                All rights reserved.                                         #
+# This file is part of the aiida-jutools package.                             #
+# (AiiDA JuDFT tools)                                                         #
+#                                                                             #
+# The code is hosted on GitHub at https://github.com/judftteam/aiida-jutools. #
+# For further information on the license, see the LICENSE.txt file.           #
+# For further information please visit http://judft.de/.                      #
+#                                                                             #
+###############################################################################
+"""Tools for working with AiiDA metadata / annotations: extras: util."""
+
+import abc
+import abc as _abc
+import typing as _typing
+
+import masci_tools.util.python_util as _masci_python_util
+from aiida import orm as _orm
+
+import aiida_jutools as _jutools
+
+
+class ExtraForm(_abc.ABC):
+    """Abstract base class for forms for standardized extras.
+
+    The extra's key and value are write-protected. This is the purpose of the form. Setting the value (or its
+    subvalues) can be implemented in two ways: a) via (recommended: mandatory, validated) constructor arguments,
+    b) via Python property getters & setters. In the latter case, if the value is not a nested data structure,
+    then a 'value' setter may be defined instead.
+
+    Each subclass must implement the abstract mtehods :py:meth:`~.clear`, :py:meth:`~.load` and :py:meth:`~.validate`.
+
+    Note: Currently does not support versioning, does not rely on external schema & form files. For design
+    considerations for implementing the latter, see the proposal "Proposal for an AiiDA extras metadata
+    standard & implementation", URL: https://iffmd.fz-juelich.de/8JZ8aLxyQSWD2byc5GKX2Q (retrieved 2021-09-20).
+    This standardization approach only makes sense if versioning is implemented, especially wrt single-value extras.
+    """
+
+    def __init__(self):
+        self._key = None
+        self._value = None
+        self._error_report_key = "ERROR_REPORT"
+
+    @property
+    def key(self) -> str:
+        """The extra's key. Read-only."""
+        return self._key
+
+    @property
+    def value(self) -> _typing.Any:
+        """The extra's value. Read-only. Set (sub)values via individual form methods."""
+        return self._value
+
+    @abc.abstractmethod
+    def load(self,
+             entity: _orm.EntityExtrasMixin,
+             **kwargs):
+        """Load an entity's extra's value into this form.
+
+        :param entity: The entity from which to load the extra.
+        :param kwargs: Specific form arguments.
+        """
+        pass
+
+    @abc.abstractmethod
+    def validate(self,
+                 **kwargs) -> bool:
+        """Validate value content. Return True for valid, False for invalid.
+
+        Form may except if validation fails. This is up to the form's implementation.
+
+        :param kwargs: Specific form arguments.
+        """
+        pass
+
+    @abc.abstractmethod
+    def clear(self):
+        """Reset form (clear all data from its value, leaving only the value's skeleton.) """
+        # regarding clear error report: either call super().clear() in implementing method, or do it yourself.
+        self._value.pop(self._error_report_key, None)
+
+    def insert(self,
+               entity: _orm.EntityExtrasMixin,
+               validate: bool = False,
+               overwrite: bool = False,
+               **kwargs) -> bool:
+        """Insert this form's extra into a given entity's extras.
+
+        :param entity: Entity into whose extras to insert.
+        :param validate: True: validate before insertion. Validation may except.
+        :param overwrite: False: Do not insert if already set.
+        :param kwargs: Specific form arguments.
+        :return: True if inserted, False if not.
+        """
+        valid = self.validate(**kwargs) if validate else True
+
+        form_cls = _jutools.meta.ExtraFormFactory(form_name='kkr_constants_version')
+        form = form_cls()
+        form.load(entity=entity)
+
+        if valid and (overwrite or not form.value):
+            entity.set_extra(self.key, self._value)
+            return True
+        return False
+
+    def insert_error_report(self, error_report: str,
+                            append_timestamp: bool = True,
+                            overwrite: bool = False) -> bool:
+        """Insert an error report into the form's value.
+
+        Will append a timestamp to the error report.
+
+        :param error_report: the error report.
+        :param append_timestamp: Append timestamp to error report string.
+        :param overwrite: False: Do not insert if already set.
+        :return: True if inserted, False if not.
+        """
+        has_report = self._value.get(self._error_report_key, None)
+        if not has_report or overwrite:
+            error_report = error_report + f" Timestamp: {_masci_python_util.now()}." \
+                if append_timestamp else error_report
+            self._value[self._error_report_key] = error_report
+            return True
+        return False
+
+
+def ExtraFormFactory(form_name: str = None) -> _typing.Optional[_typing.Type[ExtraForm]]:
+    """Factory for standardized extra forms.
+
+    Extra forms allow to use commonly used extras in a standardized format. This help in realizing data
+    FAIR-ness across different AiiDA databases.
+
+    Available extra forms:
+
+    - `'kkr_constants_version'`: Extra for setting conversion constants versions used by an AiiDA calc / workflow.
+
+    :param form_name: name of the extra form. Usually identical to name of the extra. None prints a list.
+    :return: The class of the ExtraForm for instantiation.
+    """
+    from aiida_jutools.meta.extra.forms import KkrConstantsVersionExtraForm
+
+    forms = {
+        'kkr_constants_version': KkrConstantsVersionExtraForm
+    }
+
+    if form_name not in forms:
+        print(f"Warning: No {ExtraForm.__name__} with name '{form_name}' exists. Available "
+              f"forms : {list(forms.keys())}.")
+        return None
+    return forms[form_name]

--- a/aiida_jutools/meta/extra/util.py
+++ b/aiida_jutools/meta/extra/util.py
@@ -134,7 +134,10 @@ def ExtraFormFactory(form_name: str = None) -> _typing.Optional[_typing.Type[Ext
 
     Available extra forms:
 
-    - `'kkr_constants_version'`: Extra for setting conversion constants versions used by an AiiDA calc / workflow.
+    - `'kkr_constants_version'`: Extra documenting conversion constants versions used by aiida-kkr calc / workflow.
+
+    Note: This factory is useful for use in runtime (interpreter, notebook). For use in library, direct form import
+    from :py:mod:`~.forms` should be preferred.
 
     :param form_name: name of the extra form. Usually identical to name of the extra. None prints a list.
     :return: The class of the ExtraForm for instantiation.


### PR DESCRIPTION
This is an example implementation of the metadata extras standard proposed in https://iffmd.fz-juelich.de/8JZ8aLxyQSWD2byc5GKX2Q . 

Difference to that proposal:
- Versioning has not been implemented, only an abstract `ExtraForm` and an example realization.
- The JSON-based schema is missing. This could be added after the fact, most likely without changing the API (much).
- Implementation of the higher-level proposal `ExtrasForm` / `ExtraFormSet` combining several extra forms into an extras form is missing.